### PR TITLE
Affichage des albums au défilement dans leur catégorie

### DIFF
--- a/apps/frontend/pages/categories/[slug].tsx
+++ b/apps/frontend/pages/categories/[slug].tsx
@@ -154,8 +154,8 @@ const ShowCategory: NextPage<Props> = ({
 
 export default ShowCategory;
 
-const getApiUrl = (category: number, page: number, perPage: number) =>
-  `/albums?filter[categories.id]=${category}&page=${page}&per_page=${perPage}`;
+const getApiUrl = (categoryId: number, page: number, perPage: number) =>
+  `/albums?filter[categories.id]=${categoryId}&page=${page}&per_page=${perPage}`;
 
 export const getStaticProps: GetStaticProps<Props> = async ({
   params,

--- a/apps/frontend/pages/categories/[slug].tsx
+++ b/apps/frontend/pages/categories/[slug].tsx
@@ -168,12 +168,12 @@ export const getStaticProps: GetStaticProps<Props> = async ({
       .then((res) => res.data);
 
 
-    const res = await api<PaginatedReponse<Album[]>>(getApiUrl(category.id, 1, perPage))
+    const albums = await api<PaginatedReponse<Album[]>>(getApiUrl(category.id, 1, perPage))
       .then((res) => res.json());
 
     const global = await getGlobalProps();
 
-    return { props: { category, albums: res.data, hasNextPage: res.meta.current_page < res.meta.last_page, ...global }, revalidate: 60 };
+    return { props: { category, albums: albums.data, hasNextPage: albums.meta.current_page < albums.meta.last_page, ...global }, revalidate: 60 };
   } catch (e) {
     if (e instanceof HttpNotFound) {
       return { notFound: true, revalidate: 60 };

--- a/apps/frontend/pages/categories/[slug].tsx
+++ b/apps/frontend/pages/categories/[slug].tsx
@@ -31,6 +31,8 @@ type Props = {
   hasNextPage: boolean;
 } & GlobalProps;
 
+const perPage = 12;
+
 const DynamicAdminOverlay = dynamic(
   () => import("../../components/AdminOverlay"),
   {
@@ -64,7 +66,7 @@ const ShowCategory: NextPage<Props> = ({
     if (currentPage === 1) {
       return;
     }
-    const url = getApiUrl(category.id, currentPage);
+    const url = getApiUrl(category.id, currentPage, perPage);
     api<PaginatedReponse<Album[]>>(url)
       .then((res) => res.json())
       .then((res) => {
@@ -152,8 +154,8 @@ const ShowCategory: NextPage<Props> = ({
 
 export default ShowCategory;
 
-const getApiUrl = (category: number, page: number) =>
-  `/albums?filter[categories.id]=${category}&page=${page}`;
+const getApiUrl = (category: number, page: number, perPage: number) =>
+  `/albums?filter[categories.id]=${category}&page=${page}&per_page=${perPage}`;
 
 export const getStaticProps: GetStaticProps<Props> = async ({
   params,
@@ -166,7 +168,7 @@ export const getStaticProps: GetStaticProps<Props> = async ({
       .then((res) => res.data);
 
 
-    const res = await api<PaginatedReponse<Album[]>>(getApiUrl(category.id, 1))
+    const res = await api<PaginatedReponse<Album[]>>(getApiUrl(category.id, 1, perPage))
       .then((res) => res.json());
 
     const global = await getGlobalProps();

--- a/apps/frontend/pages/galerie/index.tsx
+++ b/apps/frontend/pages/galerie/index.tsx
@@ -127,7 +127,7 @@ const IndexAlbum: NextPage<Props> = ({
 export default IndexAlbum;
 
 const getApiUrl = (page: number, perPage: number) =>
-  `/albums?page=${page}&limit=${perPage}`;
+  `/albums?page=${page}&per_page=${perPage}`;
 
 export const getStaticProps: GetStaticProps = async (): Promise<
   GetStaticPropsResult<Props>


### PR DESCRIPTION
Closes #581 

Modifications pour prendre en compte l'affichage de tous les albums en défilement ( et non plus uniquement les 10 premiers de la catégorie correspondante ). Le comportement reste inchangé si le nombre actuel d'albums dans la catégorie est inférieur ou égal à 10. 

J'émet une hypothèse pour peut-être améliorer mais j'aimerais avoir d'abord ton avis sur la question : Dans certaines pages ( dont la page /galerie par exemple ), il y a l'utilisation du composant ``AlbumList`` qui utilise lui-même le composant ``AlbumItem``. Ce dernier composant est utilisé avec une boucle dans la page catégories/[slug].tsx d'une façon similaire au composant ``AlbumList``. Toutefois, il y a quand même des changements en terme de style. 
Est-ce que c'est une volonté de ta part ? Un changement postérieur peut-être ? Est-ce qu'on pourrait peut-être harmoniser les comportements en faisant tout sous le même composant ?

Cela reste une hypothèse bien sûr, sachant que si on va dans ce sens, des modifications supplémentaires seront à faire et qu'il faudra vérifier que le CSS ait le même comportement que la production actuelle en ayant réalisé l'unification 